### PR TITLE
Allow data: null when no relationship

### DIFF
--- a/response.go
+++ b/response.go
@@ -138,6 +138,12 @@ func marshalOne(model interface{}) (*OnePayload, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// There's no data here so return Data: null
+	if rootNode.ID == "" {
+		return &OnePayload{Data: nil}, nil
+	}
+
 	payload := &OnePayload{Data: rootNode}
 
 	payload.Included = nodeMapValues(&included)


### PR DESCRIPTION
Currently, if we GET a relationship that doesn't exist, the library just returns a null body. What we instead want is to return `data: null` which is what this PR does.